### PR TITLE
use boost preprocessor to create MPACK_CPP_DEFINE macro.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,11 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   target_compile_definitions(mpack PUBLIC MPACK_DEBUG=1)
 endif()
 
+FetchContent_Declare(
+  boost_preprocessor
+  GIT_REPOSITORY https://github.com/boostorg/preprocessor.git 
+)
+FetchContent_MakeAvailable(boost_preprocessor)
 
 ###############################################################################
 # Define mpack_cpp as a header only library. 
@@ -49,7 +54,7 @@ target_include_directories(${PROJECT_NAME} INTERFACE
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
-target_link_libraries(mpack_cpp INTERFACE mpack)
+target_link_libraries(mpack_cpp INTERFACE mpack Boost::preprocessor)
 
 
 ###############################################################################
@@ -65,6 +70,8 @@ if(MPACK_CPP_BUILD_TESTS)
     # For Windows: Prevent overriding the parent project's compiler/linker settings
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
     FetchContent_MakeAvailable(googletest)
+
+
 
     include(CTest)
     enable_testing()

--- a/include/mpack_cpp/mpack_macros.hpp
+++ b/include/mpack_cpp/mpack_macros.hpp
@@ -1,0 +1,21 @@
+#ifndef MPACK_CPP__MPACK_MACROS_HPP_
+#define MPACK_CPP__MPACK_MACROS_HPP_
+
+#include "boost/preprocessor.hpp"
+
+// Each macro takes 3 parameters (r, data, elem) as required by BOOST_PP_SEQ_FOR_EACH
+#define MPACK_WRITE_FIELD_OP(r, writer, field) \
+    mpack_cpp::WriteField(writer, BOOST_PP_STRINGIZE(field), field);
+
+#define MPACK_READ_FIELD_OP(r, reader, field) \
+    mpack_cpp::ReadField(reader, BOOST_PP_STRINGIZE(field), field);
+
+#define MPACK_CPP_DEFINE(Type, ...) \
+    void to_message_pack(mpack_writer_t& writer) const { \
+        BOOST_PP_SEQ_FOR_EACH(MPACK_WRITE_FIELD_OP, writer, BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__)) \
+    } \
+    void from_message_pack(mpack_reader_t& reader) { \
+        BOOST_PP_SEQ_FOR_EACH(MPACK_READ_FIELD_OP, reader, BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__)) \
+    }
+
+#endif

--- a/tests/test_custom_allocator.cpp
+++ b/tests/test_custom_allocator.cpp
@@ -21,9 +21,9 @@ struct Animal {
 
     Animal(std::pmr::memory_resource* alloc = std::pmr::get_default_resource())
         : name(alloc), age{} {}
-    Animal(std::string_view name, int age,
+    Animal(std::string_view name_, int age_,
            std::pmr::memory_resource* alloc = std::pmr::get_default_resource())
-        : name(name, alloc), age{age} {}
+        : name(name_, alloc), age{age_} {}
 
     void to_message_pack(mpack_writer_t& writer) const {
         mpack_cpp::WriteField(writer, "name", name);
@@ -41,9 +41,9 @@ struct Zoo {
 
     Zoo(std::pmr::memory_resource* alloc = std::pmr::get_default_resource())
         : animals(alloc) {}
-    Zoo(std::initializer_list<Animal> animals,
+    Zoo(std::initializer_list<Animal> animals_,
         std::pmr::memory_resource* alloc = std::pmr::get_default_resource())
-        : animals(animals, alloc) {}
+        : animals(animals_, alloc) {}
 
     void to_message_pack(mpack_writer_t& writer) const {
         mpack_cpp::WriteField(writer, "animals", animals);


### PR DESCRIPTION
Similar to the nlohmann json macros.
Use it in the tests to remove boiler plate.